### PR TITLE
linux: build and run GUI on mono with hidapi HID transport

### DIFF
--- a/60-pickit.rules
+++ b/60-pickit.rules
@@ -1,0 +1,15 @@
+# PICkitminus programmers (PICkit2 / PICkit3 / PKOB)
+#
+# hidapi opens the /dev/hidraw* node, so the permission must be set on the
+# hidraw subsystem, not the parent usb device. The Debian/Ubuntu "plugdev"
+# group does not exist on RHEL/Fedora; granting access by that group leaves the
+# node owned by root and unreadable. TAG+="uaccess" lets systemd-logind grant
+# the active local-session user an ACL on the device, and GROUP="dialout" is a
+# fallback for non-seat sessions (eg ssh).
+#
+# PICkit 2
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="0033", MODE="0660", GROUP="dialout", TAG+="uaccess"
+# PICkit 3
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="900a", MODE="0660", GROUP="dialout", TAG+="uaccess"
+# PKOB
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="8107", MODE="0660", GROUP="dialout", TAG+="uaccess"

--- a/PICkit2V2/DialogLogic.cs
+++ b/PICkit2V2/DialogLogic.cs
@@ -441,7 +441,10 @@ namespace PICkit2V2
             else if (zoom == 3)
                 length = 4096;
 
-            Bitmap gridmap = new Bitmap(length, width, PixelFormat.Format16bppRgb555);
+            // Graphics.FromImage requires a 24/32bpp surface. libgdiplus on Linux returns a
+            // GDI+ OutOfMemory status when constructing a Graphics over a 16bpp bitmap, where
+            // Windows GDI+ tolerates it. A 24bpp RGB surface is drawable on both backends.
+            Bitmap gridmap = new Bitmap(length, width, PixelFormat.Format24bppRgb);
             Graphics graphics = Graphics.FromImage(gridmap);
             SolidBrush brush = new SolidBrush(Color.Black);
             graphics.FillRectangle(brush, 0, 0, length, width);

--- a/PICkit2V2/DialogTroubleshoot.cs
+++ b/PICkit2V2/DialogTroubleshoot.cs
@@ -8,7 +8,6 @@ using System.Windows.Forms;
 using System.Threading;
 using Pk2 = PICkit2V2.PICkitFunctions;
 using KONST = PICkit2V2.Constants;
-using USB = PICkit2V2.USB;
 
 namespace PICkit2V2
 {

--- a/PICkit2V2/FormPICkit2.cs
+++ b/PICkit2V2/FormPICkit2.cs
@@ -7500,7 +7500,11 @@ namespace PICkit2V2
 				displayStatusWindow.BackColor = Color.SteelBlue;
 				this.Update();
 
-				res = Pk3h.WriteProgrammerOs(KONST.BLFileNamePk3, 0x23);
+				// The bootloader hex is a companion of the operating system hex and resides in the
+				// same directory. Resolve it against the selected operating system file's directory
+				// rather than the process working directory.
+				string bootloaderPath = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(openFWFile.FileName), KONST.BLFileNamePk3);
+				res = Pk3h.WriteProgrammerOs(bootloaderPath, 0x23);
 
 				//TODO: better way to choose bootloader
 				if (res != KONST.PICkit2USB.bootloader)

--- a/PICkit2V2/FormPICkit2.cs
+++ b/PICkit2V2/FormPICkit2.cs
@@ -863,8 +863,17 @@ namespace PICkit2V2
 
 		[DllImport("user32.dll")]
 		static extern Int16 FlashWindowEx(ref FLASHWINFO pwfi);
-		[DllImport("user32.dll")]
-		public static extern void DisableProcessWindowsGhosting();      // 22.7.2021, v3.20.05 JAKA
+		[DllImport("user32.dll", EntryPoint = "DisableProcessWindowsGhosting")]
+		static extern void NativeDisableProcessWindowsGhosting();      // 22.7.2021, v3.20.05 JAKA
+
+		// user32.dll exists only on Windows; the native export is absent under Mono on
+		// other platforms, where window ghosting does not occur, so skip the call there
+		public static void DisableProcessWindowsGhosting()
+		{
+			if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+				return;
+			NativeDisableProcessWindowsGhosting();
+		}
 
 		// Start flush mouse events code
 		[StructLayout(LayoutKind.Sequential)]

--- a/PICkit2V2/FormPICkit2.cs
+++ b/PICkit2V2/FormPICkit2.cs
@@ -1377,13 +1377,17 @@ namespace PICkit2V2
 				pICkit2GoToolStripMenuItem.Visible = true;
 				if (Pk2.isPK2M)
 				{
+					// Mono's file dialog on Linux matches filter globs case-sensitively,
+					// while Windows folds case. The distributed operating system hex files
+					// are named in uppercase, so each filter lists the uppercase prefix
+					// pattern alongside the lowercase one to display them on both platforms.
 					//openFWFile = openFWFilePK2M;
-					openFWFile.Filter = "PK2M 2 OS|pk2mv*.hex|All files|*.*";
+					openFWFile.Filter = "PK2M 2 OS|pk2mv*.hex;PK2MV*.hex|All files|*.*";
 					openFWFile.Title = "Open PK2M Operating System File";
 				}
 				else
 				{
-					openFWFile.Filter = "PICkit 2 OS|pk2v*.hex|All files|*.*";
+					openFWFile.Filter = "PICkit 2 OS|pk2v*.hex;PK2V*.hex|All files|*.*";
 					openFWFile.Title = "Open PICkit 2 Operating System File";
 				}
 
@@ -1419,12 +1423,12 @@ namespace PICkit2V2
 
 				if (!Pk2.isPKOB)
 				{
-					openFWFile.Filter = "PICkit 3 OS|pk3os*.hex|All files|*.*";
+					openFWFile.Filter = "PICkit 3 OS|pk3os*.hex;PK3OS*.hex|All files|*.*";
 					openFWFile.Title = "Open PICkit 3 Operating System File";
 				}
 				else
 				{
-					openFWFile.Filter = "PKOB OS|pk3os*.hex|All files|*.*";
+					openFWFile.Filter = "PKOB OS|pk3os*.hex;PK3OS*.hex|All files|*.*";
 					openFWFile.Title = "Open PKOB Operating System File";
 				}
 			}

--- a/PICkit2V2/HidApiNative.cs
+++ b/PICkit2V2/HidApiNative.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace PICkit2V2
+{
+    // Raw P/Invoke bindings for the hidapi 0.12.0 library, used only on non-Windows
+    // platforms. The Mono dllmap in the application config resolves "hidapi" to the
+    // platform shared object. size_t parameters are marshalled as UIntPtr so the
+    // bindings are correct under both 32-bit and 64-bit runtimes.
+    internal static class HidApiNative
+    {
+        private const string Library = "hidapi";
+
+        // Mirrors struct hid_device_info from hidapi.h. Pointer members are held as
+        // IntPtr so the field layout and the next-node offset are correct regardless
+        // of process bitness.
+        [StructLayout(LayoutKind.Sequential)]
+        public struct hid_device_info
+        {
+            public IntPtr path;
+            public ushort vendor_id;
+            public ushort product_id;
+            public IntPtr serial_number;
+            public ushort release_number;
+            public IntPtr manufacturer_string;
+            public IntPtr product_string;
+            public ushort usage_page;
+            public ushort usage;
+            public int interface_number;
+            public IntPtr next;
+        }
+
+        [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int hid_init();
+
+        [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int hid_exit();
+
+        [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr hid_enumerate(ushort vendor_id, ushort product_id);
+
+        [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void hid_free_enumeration(IntPtr devs);
+
+        [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr hid_open_path(IntPtr path);
+
+        [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int hid_write(IntPtr device, byte[] data, UIntPtr length);
+
+        [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int hid_read_timeout(IntPtr device, byte[] data, UIntPtr length, int milliseconds);
+
+        [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void hid_close(IntPtr device);
+
+        [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int hid_get_serial_number_string(IntPtr device, byte[] str, UIntPtr maxlen);
+
+        [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int hid_get_product_string(IntPtr device, byte[] str, UIntPtr maxlen);
+
+        [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr hid_error(IntPtr device);
+
+        // hidapi wide strings use the platform wchar_t, which is four bytes (UTF-32)
+        // on the Linux and macOS targets. Decode the little-endian buffer up to the
+        // first null code unit. maxUnits is the number of wchar_t the buffer holds.
+        public static string DecodeWideString(byte[] buffer, int maxUnits)
+        {
+            return DecodeWideUnits(maxUnits, unit => BitConverter.ToInt32(buffer, unit * 4));
+        }
+
+        // Decode a null-terminated platform wchar_t string at an unmanaged pointer,
+        // as returned by hid_error. The cap bounds the scan in case the library
+        // returns a string that is not terminated within the expected length.
+        public static string PtrToWideString(IntPtr wideString)
+        {
+            if (wideString == IntPtr.Zero)
+                return "";
+            const int maxUnits = 256;
+            return DecodeWideUnits(maxUnits, unit => Marshal.ReadInt32(wideString, unit * 4));
+        }
+
+        // Build a string from successive UTF-32 code units up to the first null or
+        // maxUnits, whichever comes first. readUnit isolates the source so a managed
+        // buffer and an unmanaged pointer share one scan.
+        private static string DecodeWideUnits(int maxUnits, Func<int, int> readUnit)
+        {
+            StringBuilder builder = new StringBuilder();
+            bool terminated = false;
+            for (int unit = 0; (unit < maxUnits) && !terminated; unit++)
+            {
+                int codePoint = readUnit(unit);
+                if (codePoint == 0)
+                    terminated = true;
+                else
+                    builder.Append(char.ConvertFromUtf32(codePoint));
+            }
+            return builder.ToString();
+        }
+    }
+}

--- a/PICkit2V2/PICkit3V3.csproj
+++ b/PICkit2V2/PICkit3V3.csproj
@@ -306,7 +306,11 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
-    <Compile Include="USB.cs" />
+    <Compile Include="UsbHidContract.cs" />
+    <Compile Include="UsbHidWindows.cs" />
+    <Compile Include="HidApiNative.cs" />
+    <Compile Include="UsbHidLinux.cs" />
+    <Compile Include="UsbHidFactory.cs" />
     <Compile Include="Utilities.cs" />
     <Compile Include="DialogVDDErase.cs">
       <SubType>Form</SubType>

--- a/PICkit2V2/PICkitFunctions.cs
+++ b/PICkit2V2/PICkitFunctions.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using USB = PICkit2V2.USB;
 using KONST = PICkit2V2.Constants;
 using UTIL = PICkit2V2.Utilities;
 using System.IO;
@@ -39,10 +38,8 @@ namespace PICkit2V2
 		public static bool vddErrorDisabled = false;
 		private static IntPtr usbReadHandle = IntPtr.Zero;
 		private static IntPtr usbWriteHandle = IntPtr.Zero;
-		private static IntPtr hEventObject = IntPtr.Zero;
-		private static IntPtr wrhEventObject = IntPtr.Zero;
-		private static Kernel32.OVERLAPPED HIDOverlapped;
-		private static Kernel32.OVERLAPPED HIDWrOverlapped;
+		private static readonly IUsbHidTransport hidTransport = UsbHidFactory.Create();
+		private static string serialUnitID = "";
 		private static ushort lastPk2number = 0xFF;
 		private static int[] familySearchTable; // index is search priority, value is family array index.
 		private static bool vddOn = false;
@@ -1558,15 +1555,15 @@ namespace PICkit2V2
 		public static void DisconnectPICkit2Unit()
 		{
 			if (usbWriteHandle != IntPtr.Zero)
-				USB.CloseHandle(usbWriteHandle);
+				hidTransport.Close(usbWriteHandle);
 			if (usbReadHandle != IntPtr.Zero)
-				USB.CloseHandle(usbReadHandle);
+				hidTransport.Close(usbReadHandle);
 			usbReadHandle = IntPtr.Zero;
 			usbWriteHandle = IntPtr.Zero;
 		}
 		public static string GetSerialUnitID()
 		{
-			return USB.UnitID;
+			return serialUnitID;
 		}
 
 		public static KONST.PICkit2USB DetectPICkit2Device(ushort pk2ID, bool readFW)
@@ -1576,7 +1573,18 @@ namespace PICkit2V2
 
 			DisconnectPICkit2Unit();
 
-			bool result = USB.Find_This_Device(pk2ID, ref usbRdTemp, ref usbWrTemp);
+			Pk2DeviceInfo deviceInfo = hidTransport.FindDevice(pk2ID, out usbRdTemp, out usbWrTemp);
+			bool result = deviceInfo.Found;
+			if (deviceInfo.Found)
+			{
+				isPK3 = deviceInfo.IsPk3;
+				isPKOB = deviceInfo.IsPkob;
+				isPK2M = deviceInfo.IsPk2m;
+				ToolName = deviceInfo.ToolName;
+				serialUnitID = deviceInfo.UnitId;
+				if (deviceInfo.IsPkob)
+					pkobDeviceString = deviceInfo.PkobModel;
+			}
 
 			// If we use this check and keep the old handles, we'll read whatever packets
 			// were read by somebody else looking for pk2 units, messing up communications.
@@ -2754,65 +2762,29 @@ namespace PICkit2V2
             {
 				return false;
             }
-			if (wrhEventObject == IntPtr.Zero)
-			{
-				wrhEventObject = USB.CreateEvent
-					(IntPtr.Zero,
-					true,
-					true,
-					"");
-
-				//Set the members of the overlapped structure.
-				HIDWrOverlapped.hEvent = wrhEventObject;
-				HIDWrOverlapped.Offset = 0;
-				HIDWrOverlapped.OffsetHigh = 0;
-			}
-			uint Result;
-			bool retVal = false;
-
-			int bytesWritten = 0;
-
 			Usb_write_array[0] = 0;                         // first byte must always be zero.        
 			for (int index = 1; index < Usb_write_array.Length; index++)
 			{
 				Usb_write_array[index] = KONST.END_OF_BUFFER;              // init array to all END_OF_BUFFER cmds.
 			}
 			Array.Copy(commandList, 0, Usb_write_array, 1, commandList.Length);
-			Result = USB.WriteFile(usbWriteHandle, Usb_write_array, Usb_write_array.Length, ref bytesWritten, ref HIDWrOverlapped);
-
-			Result = USB.WaitForSingleObject(wrhEventObject, 1000);
-
-			switch (Result)
+			UsbTransferStatus status = hidTransport.Write(usbWriteHandle, Usb_write_array);
+			bool retVal;
+			if (status == UsbTransferStatus.Success)
 			{
-				case KONST.WAIT_OBJECT_0:
-					{
-						retVal = true;
-						break;
-					}
-				case KONST.WAIT_TIMEOUT:
-					{
-						//Cancel the Read operation.
-						//API call: CancelIo
-						//Cancels the ReadFile
-						//		Requires the device handle.
-						//		Returns non-zero on success.
-						
-
-						Result = USB.CancelIo(usbWriteHandle);
-						DisconnectPICkit2Unit();
-						retVal = false;
-						//A timeout may mean that the device has been removed.
-						//Close the device handles and set DeviceDetected = False
-						//so the next access attempt will search for the device.
-						break;
-					}
-				default:
-					{
-						break;
-					}
+				retVal = true;
 			}
-			
-			USB.ResetEvent(wrhEventObject);
+			else if (status == UsbTransferStatus.Timeout)
+			{
+				// A timeout may mean the device has been removed; disconnect so the next
+				// access attempt searches for the device again.
+				DisconnectPICkit2Unit();
+				retVal = false;
+			}
+			else
+			{
+				retVal = false;
+			}
 			return retVal;
 		}
 
@@ -2823,24 +2795,7 @@ namespace PICkit2V2
 			{
 				return false;
 			}
-			int bytesWritten = 0;
 			int commandLength = commandList.Length;
-			uint Result;
-			bool retVal = false;
-
-			if (wrhEventObject == IntPtr.Zero)
-			{
-				wrhEventObject = USB.CreateEvent
-					(IntPtr.Zero,
-					true,
-					true,
-					"");
-
-				//Set the members of the overlapped structure.
-				HIDWrOverlapped.hEvent = wrhEventObject;
-				HIDWrOverlapped.Offset = 0;
-				HIDWrOverlapped.OffsetHigh = 0;
-			}
 
 			Usb_write_array[0] = 0;                         // first byte must always be zero.        
 			for (int index = 1; index < Usb_write_array.Length; index++)
@@ -2855,38 +2810,21 @@ namespace PICkit2V2
 			Usb_write_array[63] = (byte)((commandLength >> 16) & 0xFF);
 			Usb_write_array[64] = (byte)((commandLength >> 24) & 0xFF);
 
-			Result = USB.WriteFile(usbWriteHandle, Usb_write_array, Usb_write_array.Length, ref bytesWritten, ref HIDWrOverlapped);
-
-			Result = USB.WaitForSingleObject(wrhEventObject, 1000);
-
-			switch (Result)
+			UsbTransferStatus status = hidTransport.Write(usbWriteHandle, Usb_write_array);
+			bool retVal;
+			if (status == UsbTransferStatus.Success)
 			{
-				case KONST.WAIT_OBJECT_0:
-					{
-						retVal = true;
-						break;
-					}
-				case KONST.WAIT_TIMEOUT:
-					{
-						//Cancel the Read operation.
-						//API call: CancelIo
-						//Cancels the ReadFile
-						//		Requires the device handle.
-						//		Returns non-zero on success.
-
-
-						Result = USB.CancelIo(usbWriteHandle);
-						DisconnectPICkit2Unit();
-						retVal = false;
-						break;
-					}
-				default:
-					{
-						break;
-					}
+				retVal = true;
 			}
-
-			USB.ResetEvent(wrhEventObject);
+			else if (status == UsbTransferStatus.Timeout)
+			{
+				DisconnectPICkit2Unit();
+				retVal = false;
+			}
+			else
+			{
+				retVal = false;
+			}
 			return retVal;
 		}
 
@@ -2896,58 +2834,22 @@ namespace PICkit2V2
 			{
 				return false;
 			}
-			if (wrhEventObject == IntPtr.Zero)
-			{
-				wrhEventObject = USB.CreateEvent
-					(IntPtr.Zero,
-					true,
-					true,
-					"");
-
-				//Set the members of the overlapped structure.
-				HIDWrOverlapped.hEvent = wrhEventObject;
-				HIDWrOverlapped.Offset = 0;
-				HIDWrOverlapped.OffsetHigh = 0;
-			}
-			uint Result;
-			bool retVal = false;
-
-			int bytesWritten = 0;
-
 			Usb_write_array[0] = 0;                         // first byte must always be zero.        
 			for (int index = 1; index < Usb_write_array.Length; index++)
 			{
 				Usb_write_array[index] = KONST.END_OF_BUFFER;              // init array to all END_OF_BUFFER cmds.
 			}
 			Array.Copy(commandList, 0, Usb_write_array, 1, commandList.Length);
-			Result = USB.WriteFile(usbWriteHandle, Usb_write_array, Usb_write_array.Length, ref bytesWritten, ref HIDWrOverlapped);
-
-			Result = USB.WaitForSingleObject(wrhEventObject, 1000);
-
-			switch (Result)
+			UsbTransferStatus status = hidTransport.Write(usbWriteHandle, Usb_write_array);
+			bool retVal;
+			if (status == UsbTransferStatus.Success)
 			{
-				case KONST.WAIT_OBJECT_0:
-					{
-						retVal = true;
-						break;
-					}
-				case KONST.WAIT_TIMEOUT:
-					{
-						
-						Result = USB.CancelIo(usbWriteHandle);
-						retVal = false;
-						//A timeout may mean that the device has been removed.
-						//Close the device handles and set DeviceDetected = False
-						//so the next access attempt will search for the device.
-						break;
-					}
-				default:
-					{
-						break;
-					}
+				retVal = true;
 			}
-
-			USB.ResetEvent(wrhEventObject);
+			else
+			{
+				retVal = false;
+			}
 			return retVal;
 		}
 
@@ -2957,59 +2859,25 @@ namespace PICkit2V2
 			{
 				return false;
 			}
-			int bytesRead = 0;
-			uint Result;
-			bool retVal = false;
-
-			if (hEventObject == IntPtr.Zero)
-			{
-				hEventObject = USB.CreateEvent
-					(IntPtr.Zero,
-					true,
-					true,
-					"");
-
-				//Set the members of the overlapped structure.
-				HIDOverlapped.hEvent = hEventObject;
-				HIDOverlapped.Offset = 0;
-				HIDOverlapped.OffsetHigh = 0;
-			}
-
 			if (LearnMode)
 				return true;
 
-			Result = USB.ReadFile(usbReadHandle, Usb_read_array, Usb_read_array.Length, ref bytesRead, ref HIDOverlapped);
-
-			Result = USB.WaitForSingleObject(hEventObject, 1000);
-			
-			switch (Result)
+			UsbTransferStatus status = hidTransport.Read(usbReadHandle, Usb_read_array);
+			bool retVal;
+			if (status == UsbTransferStatus.Success)
 			{
-				case KONST.WAIT_OBJECT_0:
-					{
-						retVal = true;
-						break;
-					}
-				case KONST.WAIT_TIMEOUT:
-					{
-						//Cancel the Read operation.
-						//API call: CancelIo
-						//Cancels the ReadFile
-						//		Requires the device handle.
-						//		Returns non-zero on success.
-						
-
-						Result = USB.CancelIo(usbReadHandle);
-						DisconnectPICkit2Unit();	// Disconnect to prevent multiple consecutive timeouts which would 'hang' the UI
-						retVal = false;
-						break;
-					}
-				default:
-					{
-						break;
-					}
+				retVal = true;
 			}
-			
-			USB.ResetEvent(hEventObject);
+			else if (status == UsbTransferStatus.Timeout)
+			{
+				// Disconnect to prevent multiple consecutive timeouts which would 'hang' the UI
+				DisconnectPICkit2Unit();
+				retVal = false;
+			}
+			else
+			{
+				retVal = false;
+			}
 			return retVal;
 		}
 
@@ -3019,51 +2887,19 @@ namespace PICkit2V2
 			{
 				return false;
 			}
-			int bytesRead = 0;
-			uint Result;
-			bool retVal = false;
-
-			if (hEventObject == IntPtr.Zero)
-			{
-				hEventObject = USB.CreateEvent
-					(IntPtr.Zero,
-					true,
-					true,
-					"");
-
-				//Set the members of the overlapped structure.
-				HIDOverlapped.hEvent = hEventObject;
-				HIDOverlapped.Offset = 0;
-				HIDOverlapped.OffsetHigh = 0;
-			}
-
 			if (LearnMode)
 				return true;
 
-			Result = USB.ReadFile(usbReadHandle, Usb_read_array, Usb_read_array.Length, ref bytesRead, ref HIDOverlapped);
-
-			Result = USB.WaitForSingleObject(hEventObject, 1000);
-
-			switch (Result)
+			UsbTransferStatus status = hidTransport.Read(usbReadHandle, Usb_read_array);
+			bool retVal;
+			if (status == UsbTransferStatus.Success)
 			{
-				case KONST.WAIT_OBJECT_0:
-					{
-						retVal = true;
-						break;
-					}
-				case KONST.WAIT_TIMEOUT:
-					{
-						Result = USB.CancelIo(usbReadHandle);
-						retVal = false;
-						break;
-					}
-				default:
-					{
-						break;
-					}
+				retVal = true;
 			}
-
-			USB.ResetEvent(hEventObject);
+			else
+			{
+				retVal = false;
+			}
 			return retVal;
 		}
 

--- a/PICkit2V2/PICkitminus.csproj
+++ b/PICkit2V2/PICkitminus.csproj
@@ -317,7 +317,11 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
-    <Compile Include="USB.cs" />
+    <Compile Include="UsbHidContract.cs" />
+    <Compile Include="UsbHidWindows.cs" />
+    <Compile Include="HidApiNative.cs" />
+    <Compile Include="UsbHidLinux.cs" />
+    <Compile Include="UsbHidFactory.cs" />
     <Compile Include="Utilities.cs" />
     <Compile Include="DialogVDDErase.cs">
       <SubType>Form</SubType>

--- a/PICkit2V2/PICkitminus.csproj.net20.xml
+++ b/PICkit2V2/PICkitminus.csproj.net20.xml
@@ -307,7 +307,11 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
-    <Compile Include="USB.cs" />
+    <Compile Include="UsbHidContract.cs" />
+    <Compile Include="UsbHidWindows.cs" />
+    <Compile Include="HidApiNative.cs" />
+    <Compile Include="UsbHidLinux.cs" />
+    <Compile Include="UsbHidFactory.cs" />
     <Compile Include="Utilities.cs" />
     <Compile Include="DialogVDDErase.cs">
       <SubType>Form</SubType>

--- a/PICkit2V2/UsbHidContract.cs
+++ b/PICkit2V2/UsbHidContract.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace PICkit2V2
+{
+    // Outcome of a single HID report transfer. The caller maps Timeout to its own
+    // disconnect policy; the transport performs any mechanism-level cancellation
+    // internally before returning.
+    public enum UsbTransferStatus
+    {
+        Success,
+        Timeout,
+        Error
+    }
+
+    // Identity of a located PICkit unit, returned by FindDevice so the transport
+    // does not reach into consumer state. PkobModel is meaningful only when IsPkob.
+    public struct Pk2DeviceInfo
+    {
+        public bool Found;
+        public string UnitId;
+        public bool IsPk3;
+        public bool IsPkob;
+        public bool IsPk2m;
+        public string ToolName;
+        public string PkobModel;
+    }
+
+    // Platform-independent HID transport for PICkit2/PICkit3/PKOB programmers.
+    // Handles are opaque to the consumer: a Win32 file handle on Windows, a hidapi
+    // device pointer on other platforms. Buffers follow the report layout where
+    // index 0 holds report id 0 and report data occupies indices 1..PACKET_SIZE-1.
+    public interface IUsbHidTransport
+    {
+        Pk2DeviceInfo FindDevice(ushort index, out IntPtr readHandle, out IntPtr writeHandle);
+        UsbTransferStatus Write(IntPtr writeHandle, byte[] buffer);
+        UsbTransferStatus Read(IntPtr readHandle, byte[] buffer);
+        void Close(IntPtr handle);
+    }
+}

--- a/PICkit2V2/UsbHidFactory.cs
+++ b/PICkit2V2/UsbHidFactory.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace PICkit2V2
+{
+    // Selects the HID transport for the current platform. Windows keeps its native
+    // hid.dll/setupapi path; every other platform uses the hidapi implementation.
+    public static class UsbHidFactory
+    {
+        public static IUsbHidTransport Create()
+        {
+            IUsbHidTransport transport;
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+                transport = new UsbHidWindows();
+            else
+                transport = new UsbHidLinux();
+            return transport;
+        }
+    }
+}

--- a/PICkit2V2/UsbHidLinux.cs
+++ b/PICkit2V2/UsbHidLinux.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Runtime.InteropServices;
+using KONST = PICkit2V2.Constants;
+
+namespace PICkit2V2
+{
+    // HID transport for non-Windows platforms, implemented over hidapi. Handles
+    // returned to the consumer are hidapi device pointers. A located unit is opened
+    // twice so the read and write handles are independent, mirroring the Windows
+    // two-handle model where DisconnectPICkit2Unit closes each handle once.
+    public class UsbHidLinux : IUsbHidTransport
+    {
+        // Number of wchar_t held by the string buffers passed to hidapi, matching the
+        // 64-unit limit the Windows path reads for serial and product strings.
+        private const int WideStringUnits = 64;
+
+        // Reusable report payload buffer, sized to the consumer buffer minus the
+        // leading report-id slot. Held across reads so the programming path does not
+        // allocate on every transfer.
+        private byte[] readReport;
+
+        public UsbHidLinux()
+        {
+            HidApiNative.hid_init();
+        }
+
+        public Pk2DeviceInfo FindDevice(ushort index, out IntPtr readHandle, out IntPtr writeHandle)
+        {
+            Pk2DeviceInfo info = new Pk2DeviceInfo();
+            info.UnitId = "";
+            info.ToolName = "PICkit 2";
+            info.PkobModel = "PKOB";
+            readHandle = IntPtr.Zero;
+            writeHandle = IntPtr.Zero;
+
+            IntPtr enumeration = HidApiNative.hid_enumerate(KONST.MChipVendorID, 0);
+            IntPtr node = enumeration;
+            ushort foundCount = 0;
+            IntPtr matchedPath = IntPtr.Zero;
+            ushort matchedProduct = 0;
+            while ((node != IntPtr.Zero) && (matchedPath == IntPtr.Zero))
+            {
+                HidApiNative.hid_device_info devInfo =
+                    (HidApiNative.hid_device_info)Marshal.PtrToStructure(node, typeof(HidApiNative.hid_device_info));
+                node = devInfo.next;
+                if (!IsSupportedProduct(devInfo.product_id))
+                    continue;
+                if (foundCount == index)
+                {
+                    matchedPath = devInfo.path;
+                    matchedProduct = devInfo.product_id;
+                }
+                else
+                {
+                    foundCount++;
+                }
+            }
+
+            if (matchedPath != IntPtr.Zero)
+            {
+                IntPtr writeDevice = HidApiNative.hid_open_path(matchedPath);
+                IntPtr readDevice = HidApiNative.hid_open_path(matchedPath);
+                if ((writeDevice != IntPtr.Zero) && (readDevice != IntPtr.Zero))
+                {
+                    PopulateIdentity(writeDevice, matchedProduct, ref info);
+                    writeHandle = writeDevice;
+                    readHandle = readDevice;
+                    info.Found = true;
+                }
+                else
+                {
+                    // One or both opens failed; release whichever succeeded so the
+                    // device file descriptors do not leak.
+                    if (writeDevice != IntPtr.Zero)
+                        HidApiNative.hid_close(writeDevice);
+                    if (readDevice != IntPtr.Zero)
+                        HidApiNative.hid_close(readDevice);
+                    // The device was enumerated but could not be opened, which on Linux
+                    // is almost always a hidraw permission problem. Report it so the
+                    // cause is visible instead of appearing as a missing device.
+                    string reason = HidApiNative.PtrToWideString(HidApiNative.hid_error(IntPtr.Zero));
+                    Console.Error.WriteLine(
+                        "PICkit device (VID 0x{0:X4} PID 0x{1:X4}) was found but could not be opened: {2}. "
+                        + "Check hidraw node permissions; see 60-pickit.rules.",
+                        KONST.MChipVendorID, matchedProduct, reason);
+                    info.Found = false;
+                }
+            }
+            else
+            {
+                info.Found = false;
+            }
+
+            if (enumeration != IntPtr.Zero)
+                HidApiNative.hid_free_enumeration(enumeration);
+            return info;
+        }
+
+        public UsbTransferStatus Write(IntPtr writeHandle, byte[] buffer)
+        {
+            if (writeHandle == IntPtr.Zero)
+                return UsbTransferStatus.Error;
+            int written = HidApiNative.hid_write(writeHandle, buffer, new UIntPtr((uint)buffer.Length));
+            UsbTransferStatus status;
+            if (written < 0)
+                status = UsbTransferStatus.Error;
+            else
+                status = UsbTransferStatus.Success;
+            return status;
+        }
+
+        public UsbTransferStatus Read(IntPtr readHandle, byte[] buffer)
+        {
+            if (readHandle == IntPtr.Zero)
+                return UsbTransferStatus.Error;
+            if ((readReport == null) || (readReport.Length != buffer.Length - 1))
+                readReport = new byte[buffer.Length - 1];
+            int read = HidApiNative.hid_read_timeout(readHandle, readReport, new UIntPtr((uint)readReport.Length), 1000);
+            UsbTransferStatus status;
+            if (read < 0)
+            {
+                status = UsbTransferStatus.Error;
+            }
+            else if (read == 0)
+            {
+                status = UsbTransferStatus.Timeout;
+            }
+            else
+            {
+                // hidapi returns unnumbered report data without the leading report id;
+                // shift the payload to index 1 so consumers see the same layout as the
+                // Windows read, where byte 0 holds report id 0.
+                buffer[0] = 0;
+                Array.Copy(readReport, 0, buffer, 1, read);
+                status = UsbTransferStatus.Success;
+            }
+            return status;
+        }
+
+        public void Close(IntPtr handle)
+        {
+            HidApiNative.hid_close(handle);
+        }
+
+        private static bool IsSupportedProduct(ushort productId)
+        {
+            return (productId == KONST.Pk2DeviceID)
+                || (productId == KONST.Pk3DeviceID)
+                || (productId == KONST.PkobDeviceID);
+        }
+
+        private static void PopulateIdentity(IntPtr device, ushort productId, ref Pk2DeviceInfo info)
+        {
+            if (productId == KONST.Pk2DeviceID)
+            {
+                info.IsPk3 = false;
+                info.IsPkob = false;
+                string productName = ReadProductString(device);
+                if (IsPk2m(productName))
+                {
+                    info.IsPk2m = true;
+                    info.ToolName = "PK2M";
+                }
+                else
+                {
+                    info.IsPk2m = false;
+                    info.ToolName = "PICkit 2";
+                }
+            }
+            else if (productId == KONST.Pk3DeviceID)
+            {
+                info.IsPk3 = true;
+                info.IsPkob = false;
+                info.ToolName = "PICkit 3";
+            }
+            else
+            {
+                // The enumeration is filtered to the three supported products, so the
+                // remaining case is PKOB.
+                info.IsPk3 = true;
+                info.IsPkob = true;
+                info.ToolName = "PKOB";
+                info.PkobModel = ReadProductString(device);
+            }
+            info.UnitId = ResolveUnitId(device);
+        }
+
+        private static bool IsPk2m(string productName)
+        {
+            return (productName.Length >= 4)
+                && (productName[0] == 'P')
+                && (productName[1] == 'K')
+                && (productName[2] == '2')
+                && (productName[3] == 'M');
+        }
+
+        private static string ResolveUnitId(IntPtr device)
+        {
+            string serial = ReadSerialString(device);
+            string unitId;
+            if ((serial.Length == 0)
+                || (serial[0] == '\t')
+                || (serial[0] == (char)0)
+                || (serial[0] == (char)0x409))
+            {
+                // Blank units report a serial that decodes to an empty or sentinel
+                // value; present it as a blank unit id, matching the Windows path.
+                unitId = "-";
+            }
+            else
+            {
+                unitId = serial;
+            }
+            return unitId;
+        }
+
+        private static string ReadProductString(IntPtr device)
+        {
+            byte[] buffer = new byte[WideStringUnits * 4];
+            HidApiNative.hid_get_product_string(device, buffer, new UIntPtr((uint)WideStringUnits));
+            return HidApiNative.DecodeWideString(buffer, WideStringUnits);
+        }
+
+        private static string ReadSerialString(IntPtr device)
+        {
+            byte[] buffer = new byte[WideStringUnits * 4];
+            HidApiNative.hid_get_serial_number_string(device, buffer, new UIntPtr((uint)WideStringUnits));
+            return HidApiNative.DecodeWideString(buffer, WideStringUnits);
+        }
+    }
+}

--- a/PICkit2V2/UsbHidWindows.cs
+++ b/PICkit2V2/UsbHidWindows.cs
@@ -2,15 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Runtime.InteropServices;
-using CONST = PICkit2V2.Constants;
 using KONST = PICkit2V2.Constants;
 
 namespace PICkit2V2
 {
-    public class USB
+    public class UsbHidWindows : IUsbHidTransport
     {
-        public static string UnitID = "";
-    
         private const uint GENERIC_READ = 0x80000000;
         private const uint GENERIC_WRITE = 0x40000000;
         private const uint FILE_SHARE_READ = 0x00000001;
@@ -157,11 +154,17 @@ namespace PICkit2V2
         [DllImport("kernel32.dll")]
         public static extern IntPtr CreateEvent(IntPtr lpEventAttributes, bool bManualReset, bool bInitialState, string lpName);
 
-        public static bool Find_This_Device(ushort p_index,
-                                           ref IntPtr p_ReadHandle,
-                                           ref IntPtr p_WriteHandle)
+        public Pk2DeviceInfo FindDevice(ushort p_index,
+                                        out IntPtr p_ReadHandle,
+                                        out IntPtr p_WriteHandle)
         {
             // Zero based p_index is used to identify which PICkit 2 we wish to talk to
+            Pk2DeviceInfo info = new Pk2DeviceInfo();
+            info.UnitId = "";
+            info.ToolName = "PICkit 2";
+            info.PkobModel = "PKOB";
+            p_ReadHandle = IntPtr.Zero;
+            p_WriteHandle = IntPtr.Zero;
             IntPtr DeviceInfoSet = IntPtr.Zero;
             IntPtr PreparsedDataPointer = IntPtr.Zero;
             HIDP_CAPS Capabilities = new HIDP_CAPS();
@@ -263,8 +266,8 @@ namespace PICkit2V2
                             {
                                 if (DeviceAttributes.ProductID == KONST.Pk2DeviceID)
                                 {
-                                    PICkitFunctions.isPK3 = false;
-                                    PICkitFunctions.isPKOB = false;
+                                    info.IsPk3 = false;
+                                    info.IsPkob = false;
                                 
                                     // Detect if PICkit2 is PK2M
                                     IntPtr ptrBuffer = Marshal.AllocHGlobal(126);
@@ -276,33 +279,33 @@ namespace PICkit2V2
 
                                     if (((byte)productName[0] == 'P') && (productName[1] == 'K') && (productName[2] == '2') && (productName[3] == 'M'))
                                     {
-                                        PICkitFunctions.isPK2M = true;
-                                        PICkitFunctions.ToolName = "PK2M";
+                                        info.IsPk2m = true;
+                                        info.ToolName = "PK2M";
                                     }
                                     else
                                     {
-                                        PICkitFunctions.isPK2M = false;
-                                        PICkitFunctions.ToolName = "PICkit 2";
+                                        info.IsPk2m = false;
+                                        info.ToolName = "PICkit 2";
                                     }
                                 }
                                 else if (DeviceAttributes.ProductID == KONST.Pk3DeviceID)
                                 {
-                                    PICkitFunctions.isPK3 = true;
-                                    PICkitFunctions.isPKOB = false;
-                                    PICkitFunctions.ToolName = "PICkit 3";
+                                    info.IsPk3 = true;
+                                    info.IsPkob = false;
+                                    info.ToolName = "PICkit 3";
                                 }
                                 else
                                 {
-                                    PICkitFunctions.isPK3 = true;
-                                    PICkitFunctions.isPKOB = true;
-                                    PICkitFunctions.ToolName = "PKOB";
+                                    info.IsPk3 = true;
+                                    info.IsPkob = true;
+                                    info.ToolName = "PKOB";
                                     
                                     // Read PKOB model
                                     IntPtr ptrBuffer = Marshal.AllocHGlobal(126);
 
                                     // get Product name string
                                     HidD_GetProductString(l_temp_handle, ptrBuffer, 126);
-                                    PICkitFunctions.pkobDeviceString = Marshal.PtrToStringUni(ptrBuffer, 64);
+                                    info.PkobModel = Marshal.PtrToStringUni(ptrBuffer, 64);
                                     Marshal.FreeHGlobal(ptrBuffer);
 
                                 }
@@ -324,11 +327,11 @@ namespace PICkit2V2
                                         // Unicode conversion turns this to character "CYRILLIC 
                                         // CAPITAL LETTER LJE". So, add an extra check to catch
                                         // it.
-                                        UnitID = "-";    // blank
+                                        info.UnitId = "-";    // blank
                                     }
                                     else
                                     {
-                                        UnitID = unitIDSerial;
+                                        info.UnitId = unitIDSerial;
                                     }
                                     // set return value
                                     p_WriteHandle = l_temp_handle;
@@ -371,7 +374,86 @@ namespace PICkit2V2
             }  // end for
             //Free the memory reserved for the DeviceInfoSet returned by SetupDiGetClassDevs.
             SetupDiDestroyDeviceInfoList(DeviceInfoSet);
-            return l_found_device;
+            info.Found = l_found_device;
+            return info;
+        }
+
+        // Overlapped event and state for the write and read paths. Each path uses a
+        // manual-reset event reused across transfers, created lazily on first use.
+        private Kernel32.OVERLAPPED wrOverlapped;
+        private Kernel32.OVERLAPPED rdOverlapped;
+        private IntPtr wrEvent = IntPtr.Zero;
+        private IntPtr rdEvent = IntPtr.Zero;
+
+        public UsbTransferStatus Write(IntPtr writeHandle, byte[] buffer)
+        {
+            if (writeHandle == IntPtr.Zero)
+                return UsbTransferStatus.Error;
+            if (wrEvent == IntPtr.Zero)
+            {
+                wrEvent = CreateEvent(IntPtr.Zero, true, true, "");
+                wrOverlapped.hEvent = wrEvent;
+                wrOverlapped.Offset = 0;
+                wrOverlapped.OffsetHigh = 0;
+            }
+            int bytesWritten = 0;
+            WriteFile(writeHandle, buffer, buffer.Length, ref bytesWritten, ref wrOverlapped);
+            uint result = WaitForSingleObject(wrEvent, 1000);
+            UsbTransferStatus status;
+            if (result == KONST.WAIT_OBJECT_0)
+            {
+                status = UsbTransferStatus.Success;
+            }
+            else if (result == KONST.WAIT_TIMEOUT)
+            {
+                // Cancel the pending overlapped write before reporting the timeout so the
+                // caller's disconnect policy starts from a quiesced handle.
+                CancelIo(writeHandle);
+                status = UsbTransferStatus.Timeout;
+            }
+            else
+            {
+                status = UsbTransferStatus.Error;
+            }
+            ResetEvent(wrEvent);
+            return status;
+        }
+
+        public UsbTransferStatus Read(IntPtr readHandle, byte[] buffer)
+        {
+            if (readHandle == IntPtr.Zero)
+                return UsbTransferStatus.Error;
+            if (rdEvent == IntPtr.Zero)
+            {
+                rdEvent = CreateEvent(IntPtr.Zero, true, true, "");
+                rdOverlapped.hEvent = rdEvent;
+                rdOverlapped.Offset = 0;
+                rdOverlapped.OffsetHigh = 0;
+            }
+            int bytesRead = 0;
+            ReadFile(readHandle, buffer, buffer.Length, ref bytesRead, ref rdOverlapped);
+            uint result = WaitForSingleObject(rdEvent, 1000);
+            UsbTransferStatus status;
+            if (result == KONST.WAIT_OBJECT_0)
+            {
+                status = UsbTransferStatus.Success;
+            }
+            else if (result == KONST.WAIT_TIMEOUT)
+            {
+                CancelIo(readHandle);
+                status = UsbTransferStatus.Timeout;
+            }
+            else
+            {
+                status = UsbTransferStatus.Error;
+            }
+            ResetEvent(rdEvent);
+            return status;
+        }
+
+        public void Close(IntPtr handle)
+        {
+            CloseHandle(handle);
         }
     }
 }

--- a/PICkit2V2/app.config
+++ b/PICkit2V2/app.config
@@ -1,3 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v2.0.50727"/></startup></configuration>
+<startup><supportedRuntime version="v2.0.50727"/></startup>
+<dllmap dll="hidapi" os="linux" target="libhidapi-hidraw.so.0"/></configuration>

--- a/README.md
+++ b/README.md
@@ -49,6 +49,30 @@ PKOB operation has been tested with the following development boards:
 
 Please Note that all new devboards have PKOB4 or some other solution, those are not supported. Also many older boards have been updated to new revision. For example Curiosity HPC board (DM164136) originally had PKOB (based on PICkit3), but revision 2 has PKOB4 (based on PICkit4). The easiest way is to look at the microcontroller type on the devboard. If it is PIC24FJ256GB106, it is very likely PKOB, and probably will work.
 
+Building on Linux
+-----------------
+The GUI software builds under Mono. Install Mono together with its build tools; on Red Hat based distributions the `mono-devel` package provides `xbuild`, `mono` and the C# compiler. Debian and Ubuntu ship the same tools in their own `mono-devel` package; where `xbuild` is not present, use `msbuild` instead, which accepts the same arguments shown below.
+
+The project files target the .NET Framework v2.0 profile, which current Mono no longer ships. Build against the installed v4.5 profile instead; the resulting assembly still runs on Mono's v4.0 runtime:
+
+```bash
+xbuild PICkit2V2/PICkitminus.csproj /p:Configuration=Release /p:Platform=x86 /p:TargetFrameworkVersion=v4.5
+```
+
+This produces `PICkit2V2/bin/Release/PICkitminus.exe`. Run it with Mono from a directory that contains the device file `PK2DeviceFile.dat`, which is loaded relative to the working directory:
+
+```bash
+mono PICkit2V2/bin/Release/PICkitminus.exe
+```
+
+See "Running on Linux" below for the hidapi runtime and USB device permissions.
+
+Running on Linux
+----------------
+The GUI software can be built and run on Linux using Mono. It talks to the PICkit2, PICkit3 and PKOB programmers through the cross-platform [hidapi](https://github.com/libusb/hidapi) library, so install the hidapi runtime (for example the `hidapi` or `libhidapi-hidraw` package for your distribution) before running.
+
+If you start the software and get a message that the PICkit 2/3/PKOB is not found, the most probable reason is that a normal user doesn't have proper rights to the USB device. A simple but ugly solution is to run as root. On systems with udev, you can instead use the [60-pickit.rules](https://github.com/jaka-fi/PICkitminus/blob/master/60-pickit.rules) file in this repository, which gives appropriate rights for PICkit2, PICkit3 and PKOB. Just copy this file to /etc/udev/rules.d/ and reload udev (or restart the PC). You will also need to re-plug the PICkit. The rules grant access to the active local-session user automatically through systemd's uaccess tag, and also add the device to the dialout group as a fallback for remote sessions. Note that the plugdev group used on Debian and Ubuntu does not exist on Red Hat based distributions; if you rely on the group fallback, make sure your user belongs to the dialout group.
+
 Downloads
 ---------
 To download this software for Windows, see 'Releases' on right edge of this github page.  &rarr;


### PR DESCRIPTION
## Description

PICkitminus only ran on Windows: the HID transport called `hid.dll`, `setupapi.dll` and kernel32 overlapped I/O directly, so under Mono on Linux it threw `DllNotFoundException: hid.dll` before the main window appeared. This change lets a single source tree build and run on both Windows and Linux.

The Windows native HID path is preserved unchanged behind a new transport interface, and a Linux implementation built on the cross-platform hidapi library is selected at runtime.

Please note I do not have a Windows system, so while I believe the Windows code paths are effectively unchanged, it needs to be tested on a Windows system. 

**Update:** It builds and runs on an arm based (Le Potato) debian system as well as x86. 

## Type of Change

- [x] Feature (non-breaking change that adds functionality)

## Implementation Details

- HID transport abstraction: `IUsbHidTransport` defines find/read/write/close; `UsbHidWindows` keeps the original `hid.dll`/`setupapi`/kernel32 calls verbatim, `UsbHidLinux` implements the same contract over hidapi, and `UsbHidFactory` selects the implementation by platform at runtime.
- `PICkitFunctions` no longer owns the overlapped-I/O event objects; its read/write wrappers call the transport and keep their existing disconnect-on-timeout policy. Device identity flows back through a `Pk2DeviceInfo` struct instead of globals.
- The Linux read shifts hidapi report data to reproduce the Windows report-id buffer layout, so consumers indexing the buffer are unchanged. A Mono dllmap resolves `hidapi` to `libhidapi-hidraw`.
- libgdiplus compatibility: the logic-analyzer bitmap uses a 24bpp surface, and Windows-only window-ghosting, file-dialog casing and bootloader-path handling are guarded or made case-insensitive for Linux.
- Packaging: the README documents the Mono build and hidapi runtime, and `60-pickit.rules` grants hidraw access via systemd uaccess with a dialout-group fallback.

## Testing

- Verified on Linux: successfully flashed `./PICkit2V2/bin/Release/PK2V023202.hex` to hardware over hidapi.
- Windows native path is unchanged and was not retested, as I do not have a Windows system to test with, hence this body of work.

<img width="558" height="665" alt="image" src="https://github.com/user-attachments/assets/112dcc68-2fd0-4f14-93ee-bea9741d72da" />
